### PR TITLE
Performance improvements

### DIFF
--- a/backuppy/cli/put.py
+++ b/backuppy/cli/put.py
@@ -18,7 +18,13 @@ def main(args: argparse.Namespace) -> None:
     if args.manifest:
         manifest = Manifest(args.filename)
         private_key_filename = backup_store.config.read('private_key_filename', default='')
-        lock_manifest(manifest, private_key_filename, backup_store._save, backup_store.options)
+        lock_manifest(
+            manifest,
+            private_key_filename,
+            backup_store._save,
+            backup_store._load,
+            backup_store.options,
+        )
     else:
         with backup_store.unlock():
             backup_store.save_if_new(args.filename)

--- a/backuppy/stores/backup_store.py
+++ b/backuppy/stores/backup_store.py
@@ -103,6 +103,7 @@ class BackupStore(metaclass=ABCMeta):
                     self._manifest,
                     self.config.read('private_key_filename', default=''),
                     self._save,
+                    self._load,
                     self.options,
                 )
                 self.rotate_manifests()

--- a/backuppy/stores/local_backup_store.py
+++ b/backuppy/stores/local_backup_store.py
@@ -48,8 +48,8 @@ class LocalBackupStore(BackupStore):
     def _query(self, prefix: str) -> List[str]:
         # self_rel_name returns things with a leading slash, but we don't necessary want to
         # require that for every possible prefix, so we add it here if it wasn't already present
-        if prefix and prefix[0] != '/':
-            prefix = '/' + prefix
+        if prefix and prefix[0] != os.sep:
+            prefix = os.sep + prefix
         results: List[str] = []
 
         for root, dirs, files in os.walk(self.backup_location):

--- a/backuppy/util.py
+++ b/backuppy/util.py
@@ -82,7 +82,7 @@ def parse_time(input_str: str) -> int:
 
 
 def path_join(*args):
-    return os.path.normpath('/'.join(args))
+    return os.path.normpath(os.sep.join(args))
 
 
 def sha_to_path(sha: str) -> str:

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -4,6 +4,6 @@ rm -rf e2e/backup e2e/restore
 if [ ! -f e2e/data/big ]; then
     dd if=/dev/urandom of=./e2e/data/big bs=10M count=200
 fi
-python -m backuppy.run --log-level debug2 --config e2e/e2e.conf backup
-python -m backuppy.run --log-level debug2 --config e2e/e2e.conf restore --name e2e_backup_test --dest e2e/restore --yes
+time python -m backuppy.run --log-level debug2 --config e2e/e2e.conf backup
+time python -m backuppy.run --log-level debug2 --config e2e/e2e.conf restore --name e2e_backup_test --dest e2e/restore --yes
 find e2e/data -type f -print0 | xargs -0 -I{} diff '{}' "e2e/restore/e2e_backup_test/$(pwd)/{}"

--- a/itests/blob_test.py
+++ b/itests/blob_test.py
@@ -4,7 +4,7 @@ import string
 import pytest
 
 from backuppy.blob import apply_diff
-from backuppy.blob import compute_sha_and_diff
+from backuppy.blob import compute_diff
 from backuppy.io import IOIter
 
 DATA_LEN = 100
@@ -47,7 +47,7 @@ def test_validate_diffs(orig_data, new_data):
 
         new_writer = new.writer(); next(new_writer)
         new_writer.send(new_data)
-        compute_sha_and_diff(orig, new, diff)
+        compute_diff(orig, new, diff)
         apply_diff(orig, diff, newnew)
 
         new.fd.seek(0)

--- a/tests/blob_test.py
+++ b/tests/blob_test.py
@@ -3,7 +3,7 @@ from hashlib import sha256
 import pytest
 
 from backuppy.blob import apply_diff
-from backuppy.blob import compute_sha_and_diff
+from backuppy.blob import compute_diff
 from backuppy.exceptions import DiffParseError
 from backuppy.exceptions import DiffTooLargeException
 
@@ -26,8 +26,8 @@ def test_round_trip(mock_open_streams, sha_fn):
     orig, new, diff = mock_open_streams
     new._fd.write(new_contents)
     sha_fn.update(new_contents)
-    sha, _ = compute_sha_and_diff(orig, new, diff)
-    assert sha == sha_fn.hexdigest()
+    compute_diff(orig, new, diff)
+    assert new.sha() == sha_fn.hexdigest()
 
     new._fd.seek(0)
     new._fd.write(b'')
@@ -36,9 +36,9 @@ def test_round_trip(mock_open_streams, sha_fn):
     assert new._fd.read() == new_contents
 
 
-def test_compute_sha_and_diff_with_large_diff(mock_open_streams):
+def test_compute_diff_with_large_diff(mock_open_streams):
     orig, new, diff = mock_open_streams
     new._fd.write(b'asdfasdfasdfa')
     new._fd.seek(0)
     with pytest.raises(DiffTooLargeException):
-        compute_sha_and_diff(orig, new, diff, 0.5)
+        compute_diff(orig, new, diff, 0.5)


### PR DESCRIPTION
 * we no longer make a copy of a "new" file before backing it up;
   given that we check the mtime during reading, if the contents of
   the file change, we will just abort and try again later.  So, making
   the copy was literally just wasting time.
 * instead of writing everything out to temporary files on disk, we
   instead write to a bytes buffer in memory unless the contents get
   too large, in which case everything gets dumped to a temporary file.
   This should make handling small files somewhat faster, at the expense
   of re-writing data to disk for large files; but since large files are
   (in theory) rarer, this seems like an OK tradeoff.  Eventually we
   want to make these values configurable anyways.

Both of these changes should help with backup time, as well as be much
more friendly for solid-state drives, since we're doing many fewer
writes to disk.

Other changes:

  * clean up unused parameters'n'stuff, fix some tests