### PR TITLE
Minor improvements to S3 storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ A minimal IAM profile for BackupPY to work is as follows:
 ```
 
 You can read more about S3 storage classes on the [AWS documentation](https://aws.amazon.com/s3/storage-classes/); valid choices are
-`STANDARD`, `REDUCED_REDUNDANCY`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`, `GLACIER`, and `DEEP_ARCHIVE`.
+`STANDARD`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`, `GLACIER`, and `DEEP_ARCHIVE`.

--- a/backuppy/run.py
+++ b/backuppy/run.py
@@ -64,6 +64,10 @@ def setup_logging(
 
         logging.getLogger().setLevel(min_log_level)
 
+        # these logs are super noisy, turn them off
+        logging.getLogger('botocore').setLevel(max(logging.INFO, log_level))
+        logging.getLogger('boto3').setLevel(max(logging.INFO, log_level))
+
 
 def main(arg_list: Optional[List[str]] = None) -> None:
     args = parse_args("BackupPY - an open-source backup tool", arg_list)

--- a/backuppy/stores/s3_backup_store.py
+++ b/backuppy/stores/s3_backup_store.py
@@ -1,4 +1,5 @@
 from typing import List
+import math
 
 import boto3
 import colorlog
@@ -7,8 +8,17 @@ from backuppy.io import BLOCK_SIZE
 from backuppy.io import IOIter
 from backuppy.stores.backup_store import BackupStore
 
-
 logger = colorlog.getLogger(__name__)
+REGULAR_STORAGE_CLASSES = {'STANDARD', 'INTELLIGENT_TIERING'}
+IA_MIN_SIZE = 128 * 1024
+GLACIER_MIN_SIZE = 40 * 1024
+
+# prices taken from AWS to figure out when its more economical
+# to use standard versus a different storage class
+STANDARD_IA_SIZE = math.ceil(0.023 / 0.0125 * IA_MIN_SIZE)
+ONEZONE_IA_SIZE = math.ceil(0.023 / 0.01 * IA_MIN_SIZE)
+GLACIER_SIZE = math.ceil(0.023 / 0.004 * GLACIER_MIN_SIZE)
+DEEP_ARCHIVE_SIZE = math.ceil(0.023 / 0.00099 * GLACIER_MIN_SIZE)
 
 
 class S3BackupStore(BackupStore):
@@ -26,23 +36,25 @@ class S3BackupStore(BackupStore):
 
     def _save(self, src: IOIter, dest: str) -> None:
         assert src.filename  # can't have a tmpfile here
+        dest = dest.replace('\\', '/')  # convert Windows separators to S3 separators
         if self._client.list_objects_v2(Bucket=self._bucket, Prefix=dest)['KeyCount'] > 0:
             logger.warning(
-                f'{src.filename} already exists in {self._bucket}; overwriting with new data',
+                f'{dest} already exists in {self._bucket}; overwriting with new data',
             )
 
-        logger.info(f'Writing {src.filename} to {self._bucket}')
+        logger.info(f'Writing {src.filename} to s3://{self._bucket}/{dest}')
         # writing objects to S3 is guaranteed to be atomic, so no need for checks here
         src.fd.seek(0)
         self._client.put_object(
             Bucket=self._bucket,
             Key=dest,
             Body=src.fd,
-            StorageClass=self.config.read_string('protocol.storage_class', default='STANDARD'),
+            StorageClass=self._compute_object_storage_class(src),
         )
 
     def _load(self, path: str, output_file: IOIter) -> IOIter:
-        logger.info(f'Reading {path} from {self._bucket}')
+        path = path.replace('\\', '/')
+        logger.info(f'Reading s3://{self._bucket}/{path} into {output_file.filename}')
         response = self._client.get_object(Bucket=self._bucket, Key=path)
         writer = output_file.writer(); next(writer)
         for data in response['Body'].iter_chunks(BLOCK_SIZE):
@@ -58,3 +70,19 @@ class S3BackupStore(BackupStore):
 
     def _delete(self, filename: str) -> None:
         self._client.delete_object(Bucket=self._bucket, Key=filename)
+
+    def _compute_object_storage_class(self, obj: IOIter) -> str:
+        """ For low-frequency access storage classes, AWS charges objects below a certain size
+        as though they were larger; if the object is less than half of that minimum size, it's
+        cheaper to store them in STANDARD """
+        storage_class = self.config.read_string('protocol.storage_class', default='STANDARD')
+        if (
+            storage_class in REGULAR_STORAGE_CLASSES
+            or (storage_class == 'STANDARD_IA' and obj.size >= STANDARD_IA_SIZE)
+            or (storage_class == 'ONEZONE_IA' and obj.size >= ONEZONE_IA_SIZE)
+            or (storage_class == 'GLACIER' and obj.size >= GLACIER_SIZE)
+            or (storage_class == 'DEEP_ARCHIVE' and obj.size >= DEEP_ARCHIVE_SIZE)
+        ):
+            return storage_class
+        else:
+            return 'STANDARD'


### PR DESCRIPTION
We only store things in a non-"STANDARD" storage class if the object is
big enough to make it cheaper to do so.

We also turn off all the botocore logging because it's super noisy.

We also also convert Windows slashes to S3 slashes.